### PR TITLE
Switched Write-Error with Write-Output at completion of the script.

### DIFF
--- a/BlackLotusKB5025885/Intune/IndividualSteps/SecureBoot-Step1-Certs-Remediation.ps1
+++ b/BlackLotusKB5025885/Intune/IndividualSteps/SecureBoot-Step1-Certs-Remediation.ps1
@@ -12,7 +12,7 @@
     Version 26.06.17
     Mike Marable
     Changes
-    - [Line 147] Changed from using "Write-Error" to "Write-Output" as the Write-Error was causing Intune to see the script as failing
+    - [Original Line 142] Changed from using "Write-Error" to "Write-Output" as the Write-Error was causing Intune to see the script as failing
 #>
 
 

--- a/BlackLotusKB5025885/Intune/IndividualSteps/SecureBoot-Step1-Certs-Remediation.ps1
+++ b/BlackLotusKB5025885/Intune/IndividualSteps/SecureBoot-Step1-Certs-Remediation.ps1
@@ -8,6 +8,11 @@
     - Updated output messages to be more user friendly and informative about the status of the remediation
     - Added more detailed comments throughout the script for clarity
     - Updated for the 4 certs vs the 1 cert
+
+    Version 26.06.17
+    Mike Marable
+    Changes
+    - [Line 147] Changed from using "Write-Error" to "Write-Output" as the Write-Error was causing Intune to see the script as failing
 #>
 
 
@@ -139,5 +144,6 @@ if ($Step1Compliance -eq $false){
     if ($GetTaskResults.RebootRequired){
         Set-PendingUpdate
     }
-    Write-Error "Setting Value for for Certificate Updates | 0x1844"
+    #Write-Error "Setting Value for for Certificate Updates | 0x1844"
+    Write-Output "Setting Value for for Certificate Updates | 0x1844"
 }

--- a/BlackLotusKB5025885/Intune/IndividualSteps/SecureBoot-Step2-BootMgr-Remediation.ps1
+++ b/BlackLotusKB5025885/Intune/IndividualSteps/SecureBoot-Step2-BootMgr-Remediation.ps1
@@ -3,6 +3,11 @@
     KB5025885 Remediation Script-Intune
     Step 2 of 4
     Version: 25.09.25
+
+    Version 26.06.17
+    Mike Marable
+    Changes
+    - [Original Line 166] Changed from using "Write-Error" to "Write-Output" as the Write-Error was causing Intune to see the script as failing
 #>
 
 #region functions
@@ -163,7 +168,8 @@ if ($Step2Complete -eq $false){
     if ($GetTaskResults.RebootRequired){
         Set-PendingUpdate
     }
-    Write-Error "Setting Value for for BootMgr Updates | 0x1944"
+    #Write-Error "Setting Value for for BootMgr Updates | 0x1944"
+    Write-Output "Setting Value for for BootMgr Updates | 0x1944"
 }
 #endregion Remediation
     


### PR DESCRIPTION
The Write-Error was sending data down the error pipeline of PowerShell.  Intune would see this and flag the Remediation script as failed.  This then prevented the Detection script to be re-executed.  Switching to Write-Output prevents this false failure and allows the Remediation script to complete successfully.